### PR TITLE
Represent fixed matrix using sized vectors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,8 @@
     "purescript-debug": "^2.0.0",
     "purescript-foldable-traversable": "^2.0.0",
     "purescript-aff": "^2.0.1",
-    "purescript-either": "^2.0.0"
+    "purescript-either": "^2.0.0",
+    "purescript-sized-vectors": "^1.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^2.0.0"

--- a/src/FixedMatrix72.purs
+++ b/src/FixedMatrix72.purs
@@ -1,66 +1,69 @@
 module App.FixedMatrix72 where
 
-import Matrix as Matrix
+import Data.Vec
+import Data.Array (mapWithIndex, zip)
 import Data.Maybe (fromJust)
-import Matrix (Matrix)
-import Partial.Unsafe (unsafePartial)
-import Data.Array (mapWithIndex)
-import Prelude (($), (<>), show, class Eq, class Show, (==), (&&))
+import Data.Typelevel.Num (class Lt, class Nat, D1, D2, D6, D7, d0, d1, d2, d3, d4, d5, d6, d7, reifyInt, (==))
+import Data.Typelevel.Num.Sets (toInt)
+import Partial.Unsafe (unsafeCrashWith)
+import Prelude (($), (<>), (<<<), show, class Eq, class Show, (&&))
 
 -- | Matrix of fixed size 7 columns x 2 rows
 -- | Flexibility in size might be in order when other Mancala boards will be added.
 newtype FixedMatrix72 a =
-  FixedMatrix72 (Matrix a)
+  FixedMatrix72 (Vec D2 (Vec D7 a))
 
-data Row = A | B
+type Row = forall n. (Nat n, Lt n D2) => n
+type Col = forall n. (Nat n, Lt n D7) => n
 
-instance eqRow :: Eq Row where
-  eq A A = true 
-  eq B B = true 
-  eq _ _ = false
+a :: Row
+a = d0
+b :: Row
+b = d1
 
-instance showRow :: Show Row where 
-  show A = "A"
-  show B = "B"
-
-newtype Ref = Ref { row :: Row, idx :: Int }
+newtype Ref = Ref { row :: Row, col :: Col }
 
 instance eqRef :: Eq Ref where
   eq (Ref r1) (Ref r2) = 
-    r1.row == r2.row && r1.idx == r2.idx 
+    r1.row == r2.row && r1.col == r2.col 
 
-instance showRef :: Show Ref where 
-  show (Ref { row, idx }) = 
-    "Ref row=" <> show row <> " idx=" <> show idx
+-- derive instance showRef :: (Show Row, Show Col) => Show Ref 
 
 init :: forall a. a -> FixedMatrix72 a
 init e =
-  FixedMatrix72 $ Matrix.repeat 7 2 e
+  FixedMatrix72 $ replicate d2 row 
+    where row = replicate d7 e
 
-makeRef :: Row -> Int -> Ref
-makeRef row idx = Ref { row, idx }
+makeRef :: Row -> Col -> Ref
+makeRef row col = Ref { row, col }
 
-getRow :: forall a. Row -> FixedMatrix72 a -> Array a
-getRow row (FixedMatrix72 m) =
-  unsafePartial fromJust v
-  where v = Matrix.getRow (rowToInt row) m
+getRow :: forall a. Row -> FixedMatrix72 a -> Vec D7 a
+getRow row (FixedMatrix72 m) = m !! row
 
 lookup :: forall a. Ref -> FixedMatrix72 a -> a
-lookup (Ref ref) (FixedMatrix72 m) =
-  unsafePartial fromJust v
-  where v = Matrix.get col row m
-        row = rowToInt ref.row
-        col = ref.idx
+lookup (Ref ref) (FixedMatrix72 m) = m !! ref.row !! ref.col
 
 modify :: forall a. Ref -> (a -> a) -> FixedMatrix72 a -> FixedMatrix72 a
 modify (Ref ref) f (FixedMatrix72 m) =
-  FixedMatrix72 $ unsafePartial fromJust v
-  where v = Matrix.modify ref.idx (rowToInt ref.row) f m
+  FixedMatrix72 $ g' m
+    where 
+      g' :: Vec D2 (Vec D7 a) -> Vec D2 (Vec D7 a)
+      g' = modifyAt ref.row f'
+      f' :: Vec D7 a -> Vec D7 a
+      f' = modifyAt ref.col f
 
 mapRowWithIndex :: forall a b. Row -> (Ref -> a -> b) -> FixedMatrix72 a -> Array b
-mapRowWithIndex row f m = mapWithIndex g $ getRow row m
-  where g idx a = f (makeRef row idx) a
+mapRowWithIndex row f m = mapWithIndex g arr 
+  where arr = toArray (getRow row m)
+        g idx e = f (makeRef row col) e
+            where col = intToCol idx
 
-rowToInt :: Row -> Int
-rowToInt A = 0
-rowToInt B = 1
+intToCol :: forall n. (Nat n, Lt n D7) => Int -> n
+intToCol 0 = d0
+intToCol 1 = d1
+intToCol 2 = d2
+intToCol 3 = d3
+intToCol 4 = d4
+intToCol 5 = d5
+intToCol 6 = d6
+intToCol 7 = d7

--- a/src/Scratch.purs
+++ b/src/Scratch.purs
@@ -1,0 +1,19 @@
+module App.Scratch where 
+
+-- We are using https://pursuit.purescript.org/packages/purescript-sized-vectors/1.0.0
+import Data.Typelevel.Num (class Lt, class Nat, toInt, D2, D7)
+import Data.Vec (Vec, modifyAt)
+import Prelude (($))
+
+newtype FixedMatrix72 a = FixedMatrix72 (Vec D2 (Vec D7 a))
+
+newtype Row = Row forall n. (Nat n, Lt n D2) => n
+newtype Col = Col forall n. (Nat n, Lt n D7) => n
+newtype Ref = Ref { row :: Row, col :: Col }
+
+instance natRow :: Nat Row where 
+  toInt (Row r) = toInt r
+
+modify :: forall a. Ref -> (a -> a) -> FixedMatrix72 a -> FixedMatrix72 a
+modify (Ref ref) f (FixedMatrix72 m) =
+  FixedMatrix72 $ modifyAt ref.row (modifyAt ref.col f) m


### PR DESCRIPTION
Sized vectors based on type-level natural numbers were [introduced by paf31](https://github.com/paf31/24-days-of-purescript-2016/blob/master/10.markdown#length-indexed-lists-bodil).

I figured it could be used to implement FixedMatrix72 without unsafe qualifiers.

There are boulders to navigate:

- [ ] [Row/Col representation using polymorphic types](http://stackoverflow.com/q/41088168/55246)